### PR TITLE
Add "A" and "B" key commands

### DIFF
--- a/Roku Network Remote.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Roku Network Remote.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -7,6 +7,8 @@
 			<Field type="menu" id="buttonSelect">
 				<Label>Button to Press:</Label>
 				<List>
+					<Option value="A">A</Option>
+					<Option value="B">B</Option>
 					<Option value="Back">Back</Option>
 					<Option value="Backspace">Backspace</Option>
 					<Option value="Down">Down</Option>


### PR DESCRIPTION
I don't know why these keys aren't listed in the network control documentation, but they work on my Roku.  These "A" and "B" key events have the same effect as the "A" and "B" buttons on my Roku remote.